### PR TITLE
Add the license and author of the original work

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,0 +1,17 @@
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,9 @@
     "license": "MIT",
     "authors": [
         {
+            "name": "Microsoft Corporation"
+        },
+        {
             "name": "Daniel Leech",
             "email": "daniel@dantleech.com"
         }


### PR DESCRIPTION
[vscode-languageserver-node](https://github.com/Microsoft/vscode-languageserver-node) is released under the [MIT License](https://choosealicense.com/licenses/mit/), which requires that any derivative works *(including transpiled PHP code)* be distributed with the copyright and license notices included.

These notations are copied from:

 * https://github.com/microsoft/vscode-languageserver-node/blob/release/protocol/3.17.6-next.11/package.json#L6
 * https://github.com/microsoft/vscode-languageserver-node/blob/release/protocol/3.17.6-next.11/License.txt