### PR TITLE
Update PHPStan 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "ergebnis/composer-normalize": "^2.0",
         "friendsofphp/php-cs-fixer": "^2.17",
-        "phpstan/phpstan": "~0.12.0",
+        "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^9.2"
     },
     "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,8 @@ parameters:
     level: 7
     paths: [ src ]
     ignoreErrors:
-        - '/If condition is always false/'
-        - '/If condition is always true/'
-        - '/Unreachable statement/'
-
+        - identifier: deadCode.unreachable
+        - identifier: empty.offset
+        - identifier: if.alwaysFalse
+        - identifier: if.alwaysTrue
+        - identifier: method.unused


### PR DESCRIPTION
[PHPStan 2.0](https://phpstan.org/blog/phpstan-2-0-released-level-10-elephpants) has been released, so update.

As of [PHPStan 1.11](https://phpstan.org/blog/phpstan-1-11-errors-identifiers-phpstan-pro-reboot), we can ignore errors by error identifier instead of error message.

Existing messages and identifiers correspond literally, but the following have been added:

### `empty.offset`

<img width="852" alt="スクリーンショット 2024-11-20 22 12 23" src="https://github.com/user-attachments/assets/903d3814-60a6-44ef-bc9c-492a2e558c94">

### `method.unused`

<img width="856" alt="スクリーンショット 2024-11-20 22 12 29" src="https://github.com/user-attachments/assets/829ec1bf-7c8f-4f8c-aba8-b1e2f3b496c4">
